### PR TITLE
Fix Issues while Decoding Secure Header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ rules.ninja
 epan/dissectors/asn1/*/*-stamp
 epan/dissectors/pidl/*-stamp
 epan/dissectors/dcerpc/*-stamp
+/build/
 
 # Doc #
 ########
@@ -184,3 +185,4 @@ vgcore.*
 Wireshark.*
 .pytest_cache/
 test/*.log
+*.orig

--- a/plugins/epan/etsi_ieee1609dot2/packet-etsi_ieee1609dot2.c
+++ b/plugins/epan/etsi_ieee1609dot2/packet-etsi_ieee1609dot2.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #include <epan/proto.h>
 #include <epan/packet.h>
@@ -527,9 +528,12 @@ static int tree_gn_cert_time64(tvbuff_t *tvb, proto_tree *ext_tree, int hf_gn_ty
   strftime(time_buf, 255, "%Y-%m-%d %H:%M:%S", time_tm);
   time_buf[255] = '\0';
 
-  proto_tree_add_uint64_format(ext_tree, hf_gn_type, tvb, offset, 8, time64_us,
-			       "Generation Time: %19s.%06d (%lu)",
-                               time_buf, time_us, time64_us);     
+  if (hf_gn_type == hf_gn_sh_field_gentime) 
+	  proto_tree_add_uint64_format(ext_tree, hf_gn_type, tvb, offset, 8, time64_us, "Generation Time: %19s.%06d (%" PRIu64 ")", time_buf, time_us, time64_us);
+  else if (hf_gn_type == hf_gn_sh_field_exptime)
+	  proto_tree_add_uint64_format(ext_tree, hf_gn_type, tvb, offset, 8, time64_us, "Expiration Time: %19s.%06d (%" PRIu64 ")", time_buf, time_us, time64_us);
+  else
+	  proto_tree_add_uint64_format(ext_tree, hf_gn_type, tvb, offset, 8, time64_us, "Time: %19s.%06d (%" PRIu64 ")", time_buf, time_us, time64_us);
 
   return 8;
 }

--- a/plugins/epan/gn/packet-gn.c
+++ b/plugins/epan/gn/packet-gn.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #include <epan/proto.h>
 #include <epan/packet.h>
@@ -979,9 +980,12 @@ static int tree_gn_cert_time64(tvbuff_t *tvb, proto_tree *ext_tree, int hf_gn_ty
   strftime(time_buf, 255, "%Y-%m-%d %H:%M:%S", time_tm);
   time_buf[255] = '\0';
 
-  proto_tree_add_uint64_format(ext_tree, hf_gn_type, tvb, offset, 8, time64_us,
-			       "Generation Time: %19s.%06d (%lu)",
-                               time_buf, time_us, time64_us);     
+  if (hf_gn_type == hf_gn_sh_field_gentime) 
+	  proto_tree_add_uint64_format(ext_tree, hf_gn_type, tvb, offset, 8, time64_us, "Generation Time: %19s.%06d (%" PRIu64 ")", time_buf, time_us, time64_us);
+  else if (hf_gn_type == hf_gn_sh_field_exptime)
+	  proto_tree_add_uint64_format(ext_tree, hf_gn_type, tvb, offset, 8, time64_us, "Expiration Time: %19s.%06d (%" PRIu64 ")", time_buf, time_us, time64_us);
+  else
+	  proto_tree_add_uint64_format(ext_tree, hf_gn_type, tvb, offset, 8, time64_us, "Time: %19s.%06d (%" PRIu64 ")", time_buf, time_us, time64_us);
 
   return 8;
 }

--- a/plugins/epan/gn/packet-gn.c
+++ b/plugins/epan/gn/packet-gn.c
@@ -4706,7 +4706,7 @@ proto_register_gn(void)
       {"Std Dev", "gn.sh.gentime.stddev", FT_UINT8, BASE_DEC, NULL, 0x00, NULL, HFILL}
     },
     { &hf_gn_sh_field_exptime,
-      {"Expiration Time", "gn.sh.exptime", FT_UINT32, BASE_DEC, NULL, 0x00, NULL, HFILL}
+      {"Expiration Time", "gn.sh.exptime", FT_UINT64, BASE_DEC, NULL, 0x00, NULL, HFILL}
     },
     { &hf_gn_sh_field_starttime,
       {"Start Time", "gn.sh.starttime", FT_UINT32, BASE_DEC, NULL, 0x00, NULL, HFILL}


### PR DESCRIPTION
Secure headers with Expiration Time could not be decoded by the ETSI-ITS-Wireshark, this fixes the length of the expiration time (was 32bit, is now 64bit) and also fixes issue where ExirationTime was shown as second GenerationTime when displayed in disector.